### PR TITLE
fix: resolve __dirname in Next.js config

### DIFF
--- a/license-key/next.config.js
+++ b/license-key/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      '@': path.resolve(__dirname, 'src'),
+      '@': path.resolve(process.cwd(), 'src'),
     }
     return config
   },

--- a/license-key/types/nodemailer.d.ts
+++ b/license-key/types/nodemailer.d.ts
@@ -1,0 +1,1 @@
+declare module 'nodemailer';


### PR DESCRIPTION
## Summary
- fix license-key Next.js config to avoid `__dirname` in ESM
- add nodemailer type declaration to satisfy TypeScript

## Testing
- `DATABASE_URL="file:./dev.db" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba7a2f2e708330a3f5d2f27755d2d5