### PR TITLE
feat: add email to license verification

### DIFF
--- a/contact-agent-mvp/README.md
+++ b/contact-agent-mvp/README.md
@@ -18,6 +18,9 @@ ENGINE_WORKDIR=/absolute/path/to/python-engine-repo
 
 # 常時付けたい共通フラグ（任意）
 ENGINE_DEFAULT_ARGS=--fast
+
+# ライセンス認証APIのベースURL
+LICENSE_SYSTEM_URL=http://localhost:3001
 ```
 
 ## 開発サーバー起動

--- a/contact-agent-mvp/src/app/api/auth/verify-license/route.ts
+++ b/contact-agent-mvp/src/app/api/auth/verify-license/route.ts
@@ -4,12 +4,13 @@ import { z } from "zod";
 export const runtime = "nodejs";
 
 const Body = z.object({
+  email: z.string().email(),
   licenseKey: z.string().min(8),
 });
 
 export async function POST(req: NextRequest) {
   try {
-    const { licenseKey } = Body.parse(await req.json());
+    const { email, licenseKey } = Body.parse(await req.json());
 
     // 環境変数の取得状況をログ出力
     const licenseSystemUrl = process.env.LICENSE_SYSTEM_URL || 'http://localhost:3001';
@@ -25,11 +26,7 @@ export async function POST(req: NextRequest) {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        email: 'admin@contact-agent.com', // 管理者用の固定メールアドレス
-        licenseKey: licenseKey,
-        device: 'contact-agent-mvp'
-      }),
+      body: JSON.stringify({ email, licenseKey }),
     });
 
     if (response.ok) {

--- a/contact-agent-mvp/src/components/license-screen.tsx
+++ b/contact-agent-mvp/src/components/license-screen.tsx
@@ -12,6 +12,7 @@ interface LicenseScreenProps {
 }
 
 export function LicenseScreen({ onLicenseValid }: LicenseScreenProps) {
+  const [email, setEmail] = useState('');
   const [licenseKey, setLicenseKey] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
@@ -28,7 +29,10 @@ export function LicenseScreen({ onLicenseValid }: LicenseScreenProps) {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ licenseKey: licenseKey.trim() }),
+        body: JSON.stringify({
+          email: email.trim(),
+          licenseKey: licenseKey.trim(),
+        }),
       });
 
       const result = await response.json();
@@ -66,6 +70,17 @@ export function LicenseScreen({ onLicenseValid }: LicenseScreenProps) {
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <Input
+                type="email"
+                placeholder="メールアドレスを入力してください"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="text-center text-lg"
+                disabled={isLoading}
+                required
+              />
+            </div>
+            <div>
+              <Input
                 type="text"
                 placeholder="ライセンスキーを入力してください"
                 value={licenseKey}
@@ -87,7 +102,9 @@ export function LicenseScreen({ onLicenseValid }: LicenseScreenProps) {
               type="submit"
               className="w-full"
               size="lg"
-              disabled={isLoading || !licenseKey.trim()}
+              disabled={
+                isLoading || !email.trim() || !licenseKey.trim()
+              }
             >
               {isLoading ? '認証中...' : '認証する'}
             </Button>

--- a/contact-agent-mvp/src/store/license-store.ts
+++ b/contact-agent-mvp/src/store/license-store.ts
@@ -7,7 +7,7 @@ interface LicenseState {
   setLicenseValid: (key: string) => void;
   clearLicense: () => void;
   checkLicense: () => boolean;
-  verifyLicense: (key: string) => Promise<boolean>;
+  verifyLicense: (email: string, key: string) => Promise<boolean>;
 }
 
 export const useLicenseStore = create<LicenseState>()(
@@ -52,14 +52,14 @@ export const useLicenseStore = create<LicenseState>()(
         return get().isLicenseValid;
       },
 
-      verifyLicense: async (key: string) => {
+      verifyLicense: async (email: string, key: string) => {
         try {
           const response = await fetch('/api/auth/verify-license', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ licenseKey: key }),
+            body: JSON.stringify({ email, licenseKey: key }),
           });
 
           const result = await response.json();


### PR DESCRIPTION
## Summary
- add email field to license screen and include in verification request
- forward {email, licenseKey} to license system and document LICENSE_SYSTEM_URL env var
- adjust license store to send email when verifying

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68be356f106883309a2e449a0edda503