### PR TITLE
feat: use NEXT_PUBLIC_APP_URL env var and fix purchase submit

### DIFF
--- a/license-key/.env.example
+++ b/license-key/.env.example
@@ -18,5 +18,5 @@ SMTP_FROM="noreply@example.com"
 APP_NAME="My App"
 APP_BASE_URL="http://localhost:3000"
 
-# Optional: base URL used by server actions when calling internal API
+# Base URL used by server actions when calling internal API
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/license-key/README.md
+++ b/license-key/README.md
@@ -46,6 +46,8 @@ SMTP_FROM="Your App <no-reply@example.com>"
 # アプリ表示
 APP_NAME="My License App"
 APP_BASE_URL="http://localhost:3000"
+# サーバーアクションで内部APIを呼び出すベースURL
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
 ```
 
 ### 3. データベースの初期化

--- a/license-key/app/admin/actions.ts
+++ b/license-key/app/admin/actions.ts
@@ -27,7 +27,7 @@ export async function issueLicenseAction(_prevState: State, formData: FormData):
   const body = parsed.data;
 
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/admin/issue-license`, {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_APP_URL ?? ''}/api/admin/issue-license`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',

--- a/purchase-page/app/purchase/page.tsx
+++ b/purchase-page/app/purchase/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
@@ -25,6 +25,7 @@ export default function PurchasePage() {
   const [currentStep, setCurrentStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
+  const formStartTimeRef = useRef(Date.now());
 
   const form = useForm<PurchaseFormData>({
     resolver: zodResolver(purchaseFormSchema),
@@ -107,7 +108,7 @@ export default function PurchasePage() {
         },
         body: JSON.stringify({
           ...data,
-          submitTime: Date.now(),
+          submitTime: formStartTimeRef.current,
           honeypot: "", // ハニーポット
         }),
       });


### PR DESCRIPTION
## Summary
- replace `NEXT_PUBLIC_BASE_URL` with `NEXT_PUBLIC_APP_URL`
- document the new env var in `.env.example` and README
- ensure purchase form passes timing check so the final submit button responds

## Testing
- `npm install` *(fails: 403 Forbidden - iconv-lite)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be54a93dd48330b8ce2c4513019430