### PR TITLE
refactor: lazy initialize firebase admin

### DIFF
--- a/license-key/app/api/admin/issue-license/route.ts
+++ b/license-key/app/api/admin/issue-license/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
+import { getDb } from "@/lib/firebase";
 import { generateKeyId, generateSecret, formatLicense, hashSecret } from "@/lib/license";
 import { z } from "zod";
 import { sendLicenseEmail } from "@/lib/mailer";
@@ -34,6 +34,7 @@ export async function POST(req: NextRequest) {
   console.log('Secret Hash:', secretHash);
   console.log('=====================================');
 
+  const db = getDb();
   const licRef = await db.collection("licenses").add({
     email,
     keyId,

--- a/license-key/app/api/auth/activate/route.ts
+++ b/license-key/app/api/auth/activate/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { db } from "@/lib/firebase";
+import { getDb } from "@/lib/firebase";
 import { FieldValue } from "firebase-admin/firestore";
 import { parseLicense, verifySecret } from "@/lib/license";
 import { createAccessToken } from "@/lib/jwt";
@@ -16,6 +16,7 @@ const Body = z.object({
 
 export async function POST(req: NextRequest) {
   const { email, licenseKey, device } = Body.parse(await req.json());
+  const db = getDb();
 
   // デバッグ情報を出力
   console.log('=== ライセンス認証（デバッグ） ===');

--- a/license-key/src/lib/firebase.ts
+++ b/license-key/src/lib/firebase.ts
@@ -1,14 +1,21 @@
-import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
+import { cert, getApps, initializeApp } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
 
-if (!getApps().length) {
-  initializeApp({
-    credential: cert({
-      projectId: process.env.FIREBASE_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\n/g, '\n'),
-    }),
-  });
+export function getDb() {
+  if (!getApps().length) {
+    const projectId = process.env.FIREBASE_PROJECT_ID;
+    const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+    const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n');
+
+    if (!projectId || !clientEmail || !privateKey) {
+      throw new Error("Missing Firebase credentials");
+    }
+
+    initializeApp({
+      credential: cert({ projectId, clientEmail, privateKey }),
+    });
+  }
+
+  return getFirestore();
 }
 
-export const db = getFirestore();


### PR DESCRIPTION
## Summary
- lazily initialize Firebase Admin to avoid build-time failure when env vars absent
- fetch Firestore instance within API handlers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase-admin)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa04564988330b25eada87e09d1a2