### PR TITLE
Handle missing Firebase config in license APIs

### DIFF
--- a/license-key/app/api/admin/issue-license/route.ts
+++ b/license-key/app/api/admin/issue-license/route.ts
@@ -35,6 +35,9 @@ export async function POST(req: NextRequest) {
   console.log('=====================================');
 
   const db = getDb();
+  if (!db) {
+    return NextResponse.json({ error: "SERVER_ERROR" }, { status: 500 });
+  }
   const licRef = await db.collection("licenses").add({
     email,
     keyId,

--- a/license-key/app/api/auth/activate/route.ts
+++ b/license-key/app/api/auth/activate/route.ts
@@ -17,6 +17,9 @@ const Body = z.object({
 export async function POST(req: NextRequest) {
   const { email, licenseKey, device } = Body.parse(await req.json());
   const db = getDb();
+  if (!db) {
+    return NextResponse.json({ error: "SERVER_ERROR" }, { status: 500 });
+  }
 
   // デバッグ情報を出力
   console.log('=== ライセンス認証（デバッグ） ===');

--- a/license-key/src/lib/firebase.ts
+++ b/license-key/src/lib/firebase.ts
@@ -1,14 +1,14 @@
 import { cert, getApps, initializeApp } from "firebase-admin/app";
-import { getFirestore } from "firebase-admin/firestore";
+import { Firestore, getFirestore } from "firebase-admin/firestore";
 
-export function getDb() {
+export function getDb(): Firestore | null {
   if (!getApps().length) {
     const projectId = process.env.FIREBASE_PROJECT_ID;
     const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-    const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n');
+    const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
 
     if (!projectId || !clientEmail || !privateKey) {
-      throw new Error("Missing Firebase credentials");
+      return null;
     }
 
     initializeApp({


### PR DESCRIPTION
## Summary
- Safely return `null` from `getDb` when Firebase env vars are missing
- Return 500 errors in API routes if Firestore instance cannot be obtained

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa631b9bc8330ab14c3df1e0111d9