### PR TITLE
fix: add explicit order type for checkout API

### DIFF
--- a/purchase-page/app/api/checkout/route.ts
+++ b/purchase-page/app/api/checkout/route.ts
@@ -3,6 +3,19 @@ import Stripe from "stripe";
 import { getDb } from "@/lib/firebase";
 import { withRateLimit } from "@/lib/rateLimit";
 
+interface Order {
+  id: string;
+  paymentMethod: string;
+  status: string;
+  totalAmount: number;
+  company: {
+    name: string;
+  };
+  contact: {
+    email: string;
+  };
+}
+
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2023-10-16",
 });
@@ -28,8 +41,11 @@ async function createPaymentIntent(request: NextRequest) {
       return NextResponse.json({ error: "注文が見つかりません" }, { status: 404 });
     }
 
-    const orderData = orderDoc.data();
-    const order = {
+    const orderData = orderDoc.data() as Order | undefined;
+    if (!orderData) {
+      return NextResponse.json({ error: "注文データが不正です" }, { status: 500 });
+    }
+    const order: Order = {
       id: orderDoc.id,
       ...orderData,
     };


### PR DESCRIPTION
## Summary
- add Order interface to checkout API
- validate fetched order data before using

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcba70ebc8330a72961851a543b69