### PR TITLE
feat: use node-rs argon2 for license hashing

### DIFF
--- a/license-key/package.json
+++ b/license-key/package.json
@@ -12,7 +12,7 @@
     "@types/node": "24.3.1",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
-    "argon2": "^0.41.1",
+    "@node-rs/argon2": "^1.7.1",
     "autoprefixer": "^10.4.0",
     "firebase-admin": "^12.0.0",
     "jose": "^5.9.6",

--- a/license-key/src/lib/license.ts
+++ b/license-key/src/lib/license.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import argon2 from "argon2";
+import { hash, verify } from "@node-rs/argon2";
 
 function group4(s: string) {
   return s.match(/.{1,4}/g)?.join("-") ?? s;
@@ -29,9 +29,9 @@ export function parseLicense(full: string) {
 }
 
 export async function hashSecret(secret: string) {
-  return argon2.hash(secret);
+  return hash(secret);
 }
 
-export async function verifySecret(hash: string, secret: string) {
-  return argon2.verify(hash, secret);
+export async function verifySecret(hashString: string, secret: string) {
+  return verify(hashString, secret);
 }


### PR DESCRIPTION
## Summary
- replace argon2 dependency with `@node-rs/argon2`
- update license hashing utilities to use `@node-rs/argon2`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@node-rs%2fargon2)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7821c3c8330b504d0bb3da7b321