### PR TITLE
Fix license auto issue endpoint path

### DIFF
--- a/purchase-page/app/api/orders/route.ts
+++ b/purchase-page/app/api/orders/route.ts
@@ -70,7 +70,7 @@ async function createOrder(request: NextRequest) {
 
     if (process.env.AUTO_ISSUE_LICENSE === 'true') {
       const res = await fetch(
-        `${process.env.LICENSE_SYSTEM_URL}/api/admin/issueLicense`,
+        `${process.env.LICENSE_SYSTEM_URL}/api/admin/issue-license`,
         {
           method: 'POST',
           headers: {


### PR DESCRIPTION
## Summary
- point automatic license issue request to the hyphenated admin API route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8c5726c6483308db98b45be4db8c1