### PR TITLE
Add purchase completion notice on confirm page

### DIFF
--- a/purchase-page/app/purchase/confirm/page.tsx
+++ b/purchase-page/app/purchase/confirm/page.tsx
@@ -5,8 +5,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { formatPrice, getPlanDisplayName, convertFormPlanToDbPlan } from "@/lib/price";
-import { ArrowLeft, Edit, CheckCircle } from "lucide-react";
+import { ArrowLeft, Edit, CheckCircle, MailCheck } from "lucide-react";
 
 interface OrderData {
   id: string;
@@ -164,6 +165,19 @@ export default function ConfirmPage() {
           </p>
         </div>
 
+        <Alert className="mb-6 border-green-200 bg-green-50 text-green-800">
+          <MailCheck className="h-5 w-5 text-green-600" />
+          <AlertTitle>購入が完了しました</AlertTitle>
+          <AlertDescription>
+            <p className="mb-1">お申し込み内容を受け付けました。</p>
+            <p>
+              ライセンスキーは登録されたメールアドレス（
+              <span className="font-semibold">{orderData.contact.email}</span>
+              ）にお送りいたします。
+            </p>
+          </AlertDescription>
+        </Alert>
+
         <div className="space-y-6">
           {/* 会社情報 */}
           <Card>
@@ -271,11 +285,12 @@ export default function ConfirmPage() {
               <ArrowLeft className="h-4 w-4 mr-2" />
               フォームに戻る
             </Button>
-            
-            <Button 
-              onClick={handleProceed} 
+
+            <Button
+              onClick={handleProceed}
               disabled={isProcessing}
               className="bg-blue-600 hover:bg-blue-700"
+              data-testid="proceed-button"
             >
               {isProcessing ? (
                 "処理中..."

--- a/purchase-page/tests/e2e/purchase-flow.spec.ts
+++ b/purchase-page/tests/e2e/purchase-flow.spec.ts
@@ -39,6 +39,7 @@ test.describe("Purchase Flow", () => {
 
     // 確認ページ
     await expect(page).toHaveURL(/\/purchase\/confirm/);
+    await expect(page.locator("text=購入が完了しました")).toBeVisible();
     await expect(page.locator("text=注文内容の確認")).toBeVisible();
     await expect(page.locator("text=株式会社テスト")).toBeVisible();
     await expect(page.locator("text=田中太郎")).toBeVisible();
@@ -80,6 +81,7 @@ test.describe("Purchase Flow", () => {
 
     // 確認ページ
     await expect(page).toHaveURL(/\/purchase\/confirm/);
+    await expect(page.locator("text=購入が完了しました")).toBeVisible();
     await expect(page.locator("text=請求書払い")).toBeVisible();
 
     // 見積書を生成


### PR DESCRIPTION
## Summary
- add a completion alert to the purchase confirmation page reminding users that the licence key will be emailed
- expose the proceed button with a test id so the e2e flow can interact with it
- update the e2e purchase flow expectations to include the new completion message

## Testing
- npm run test:e2e -- --project=chromium *(fails: Playwright CLI not available in the environment)*
- npm test *(fails: Jest CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8dfb619448330b6e6fda107c75cec